### PR TITLE
fix: timing of clearing virtual text

### DIFF
--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -66,17 +66,16 @@ end
 --- Update lightbulb virtual text.
 ---
 --- @param text string The text of virtual text
---- @param line number The line to add the virtual text
+--- @param line number|nil The line to add the virtual text
 ---
 --- @private
 local function _update_virtual_text(text, line)
     vim.api.nvim_buf_clear_namespace(0, LIGHTBULB_VIRTUAL_TEXT_NS, 0, -1)
 
     if line then
-        vim.api.nvim_buf_set_virtual_text(0, LIGHTBULB_VIRTUAL_TEXT_NS, line, {{text, LIGHTBULB_VIRTUAL_TEXT_HL}}, {})
-
-        local events = { "CursorMoved", "CursorMovedI", "BufHidden", "BufLeave" }
-        vim.cmd("autocmd "..table.concat(events, ",").." <buffer> ++once call nvim_buf_clear_namespace(0, "..LIGHTBULB_VIRTUAL_TEXT_NS..", 0, -1)")
+        vim.api.nvim_buf_set_virtual_text(
+            0, LIGHTBULB_VIRTUAL_TEXT_NS, line, {{text, LIGHTBULB_VIRTUAL_TEXT_HL}}, {}
+        )
     end
 end
 


### PR DESCRIPTION
Once I tried to implement it the same way as X, but it did not clear the virtual text correctly, so I implemented it a little differently.
Please review the code.


*When implemented in the same way as _update_sign:*

![lightbulb_pr2](https://user-images.githubusercontent.com/16581287/108197605-f1f20780-715d-11eb-8ad4-44ac3c1fecdb.gif)


*Implementation in this PR:*

![lightbulb_pr3](https://user-images.githubusercontent.com/16581287/108198026-747ac700-715e-11eb-94c9-8d19466bf1ed.gif)



Refer https://github.com/kosayoda/nvim-lightbulb/pull/5