### PR TITLE
Add function to allow easy statusline integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ require'nvim-lightbulb'.update_lightbulb {
         enabled = false,
         -- Text to show at virtual text
         text = "💡",
+    },
+    status_text = {
+        enabled = false,
+        -- Text to show at when status text requested
+        text = "💡",
+        -- Text to show when status text requested and no actions available
+        not_lit_text = ""
     }
 }
 ```
@@ -109,3 +116,10 @@ Lua:
 vim.api.nvim_command('highlight LightBulbFloatWin ctermfg= ctermbg= guifg= guibg=')
 vim.api.nvim_command('highlight LightBulbVirtualText ctermfg= ctermbg= guifg= guibg=')
 ```
+
+##### Status-line text usage
+
+With the status_text option enabled you can access the current lightbulb state
+through the lua function `require'nvim-lightbulb'.get_status_text()`. This
+allows easy integration with multiple different status line plugins.
+

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ require'nvim-lightbulb'.update_lightbulb {
     },
     status_text = {
         enabled = false,
-        -- Text to show at when status text requested
+        -- Text to provide when code actions are available
         text = "💡",
-        -- Text to show when status text requested and no actions available
-        not_lit_text = ""
+        -- Text to provide when no actions are available
+        text_unavailable = ""
     }
 }
 ```
@@ -122,4 +122,3 @@ vim.api.nvim_command('highlight LightBulbVirtualText ctermfg= ctermbg= guifg= gu
 With the status_text option enabled you can access the current lightbulb state
 through the lua function `require'nvim-lightbulb'.get_status_text()`. This
 allows easy integration with multiple different status line plugins.
-

--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -160,7 +160,7 @@ M.update_lightbulb = function(config)
         status_text = {
             enabled = false,
             text = "💡",
-            not_lit_text = ""
+            text_unavailable = ""
         }
     }
 

--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -1,7 +1,6 @@
 local vim = vim
 local lsp_util = require("vim.lsp.util")
 local M = {}
-local current_lightbulb_status_text = ""
 
 local SIGN_GROUP = "nvim-lightbulb"
 local SIGN_NAME = "LightBulbSign"
@@ -80,8 +79,12 @@ local function _update_virtual_text(text, line)
     end
 end
 
+--- Update lightbulb status text
+--- 
+--- @param text string The new status text
+---
 local function _update_status_text(text)
-    current_lightbulb_status_text = text
+    vim.b.current_lightbulb_status_text = text
 end
 
 --- Handler factory to keep track of current lightbulb line.
@@ -135,7 +138,7 @@ local function handler_factory(opts, line)
 end
 
 M.get_status_text = function()
-    return current_lightbulb_status_text
+    return vim.b.current_lightbulb_status_text
 end
 
 M.update_lightbulb = function(config)
@@ -157,7 +160,7 @@ M.update_lightbulb = function(config)
         status_text = {
             enabled = false,
             text = "💡",
-            non_lit_text = "OFF"
+            not_lit_text = ""
         }
     }
 

--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -138,7 +138,7 @@ local function handler_factory(opts, line)
 end
 
 M.get_status_text = function()
-    return vim.b.current_lightbulb_status_text
+    return vim.b.current_lightbulb_status_text or ""
 end
 
 M.update_lightbulb = function(config)

--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -112,7 +112,7 @@ local function handler_factory(opts, line)
                 _update_virtual_text(opts.virtual_text.text, nil)
             end
             if opts.status_text.enabled then
-                _update_status_text(opts.status_text.not_lit_text)
+                _update_status_text(opts.status_text.text_unavailable)
             end
         else
             if opts.sign.enabled then


### PR DESCRIPTION
Thanks for this plugin, it's a really nice way to aid the discoverability of the code actions!

I found I prefer the lightbulb to be in only one static place on the screen, and the statusline seemed a good place to show it. It seemed reasonable to allow this plugin to handle the LSP integration and expose a simple lua function out for the statusline plugins to call to get the latest lightbulb state. Since this has a static presence on the screen I provided the ability to also show a different text when there are no actions, such that a different icon can be used for that rather than absence of icon.

Thought that this might be of use to other people. I tried to follow the other conventions in the plugin and keep it simple, but happy to change things around if you'd prefer it another way.