### PR TITLE
fix signature of code action handler

### DIFF
--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -111,7 +111,7 @@ local function handler_factory(opts, line)
     --- See lsp-handler for more information.
     ---
     --- @private
-    local function code_action_handler(err, _, actions)
+    local function code_action_handler(err, actions)
         -- The request returns an error
         if err then
             return


### PR DESCRIPTION
The signature for LSP handler function has changed in neovim/neovim#15504.
While in the past the third passed argument was the result (i.e. the actions) it
is now the second. The third argument is now the context which is never nil or
empty. As result the light bulb was always displayed at any location. The
evaluation if there is a code action or not was simply broken.