### PR TITLE
Fix virtual text hl_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ require'nvim-lightbulb'.update_lightbulb {
         enabled = false,
         -- Text to show at virtual text
         text = "💡",
+        -- highlight mode to use for virtual text (replace, combine, blend), see :help nvim_buf_set_extmark() for reference
+        hl_mode = "replace",
     },
     status_text = {
         enabled = false,

--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -82,18 +82,18 @@ end
 
 --- Update lightbulb virtual text.
 ---
---- @param text string The text of virtual text
+--- @param opts table Available options for the virtual text handler
 --- @param line number|nil The line to add the virtual text
 --- @param bufnr number|nil Buffer handle
 ---
 --- @private
-local function _update_virtual_text(text, line, bufnr)
+local function _update_virtual_text(opts, line, bufnr)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
     vim.api.nvim_buf_clear_namespace(bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, 0, -1)
 
     if line then
         vim.api.nvim_buf_set_extmark(
-            bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, line, -1, { virt_text = {{ text }}, hl_group = LIGHTBULB_VIRTUAL_TEXT_HL, hl_mode = 'combine' }
+            bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, line, -1, { virt_text = {{ opts.text, LIGHTBULB_VIRTUAL_TEXT_HL }}, hl_mode = opts.hl_mode }
         )
     end
 end
@@ -167,7 +167,7 @@ local function handler_factory(opts, line, bufnr)
             end
 
             if opts.virtual_text.enabled then
-                _update_virtual_text(opts.virtual_text.text, line, bufnr)
+                _update_virtual_text(opts.virtual_text, line, bufnr)
             end
 
             if opts.status_text.enabled then
@@ -199,7 +199,8 @@ M.update_lightbulb = function(config)
         },
         virtual_text = {
             enabled = false,
-            text = "💡"
+            text = "💡",
+            hl_mode = "replace"
         },
         status_text = {
             enabled = false,

--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -152,7 +152,7 @@ local function handler_factory(opts, line, bufnr)
                 _update_sign(opts.sign.priority, vim.b.lightbulb_line, nil, bufnr)
             end
             if opts.virtual_text.enabled then
-                _update_virtual_text(opts.virtual_text.text, nil, bufnr)
+                _update_virtual_text(opts.virtual_text, nil, bufnr)
             end
             if opts.status_text.enabled then
                 _update_status_text(opts.status_text.text_unavailable, bufnr)

--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -92,8 +92,8 @@ local function _update_virtual_text(text, line, bufnr)
     vim.api.nvim_buf_clear_namespace(bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, 0, -1)
 
     if line then
-        vim.api.nvim_buf_set_virtual_text(
-            bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, line, {{text, LIGHTBULB_VIRTUAL_TEXT_HL}}, {}
+        vim.api.nvim_buf_set_extmark(
+            bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, line, -1, { virt_text = {{ text }}, hl_group = LIGHTBULB_VIRTUAL_TEXT_HL, hl_mode = 'combine' }
         )
     end
 end


### PR DESCRIPTION
Lightbulb was using the old `nvim_buf_set_virtual_text()` api that doesn't apply the underlying highlight (cursorline).

I migrated to the newer `nvim_buf_set_extmark()` api and set `hl_mode="combine"`
