### PR TITLE
fix: check for code action support

### DIFF
--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -189,7 +189,7 @@ M.update_lightbulb = function(config)
     -- Check for code action capability
     local code_action_cap_found = false
     for _, client in ipairs(vim.lsp.buf_get_clients()) do
-        if client.resolved_capabilities.code_action then
+        if client.supports_method("textDocument/codeAction") then
             code_action_cap_found = true
             break
         end


### PR DESCRIPTION
Use `client.supports_method("textDocument/codeAction")` instead of `client.resolved_capabilities.code_action `
See https://github.com/jose-elias-alvarez/null-ls.nvim/issues/261#issuecomment-944844995

Fixes https://github.com/kosayoda/nvim-lightbulb/issues/20 on the `nvim-lightbulb` side