### PR TITLE
Allow users to specify defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ vim.cmd [[autocmd CursorHold,CursorHoldI * lua require'nvim-lightbulb'.update_li
 
 ### Configuration
 
-##### Available options:
+##### Set defaults
+
+Configuration can be passed to the setup function.
+
 ```lua
 -- Showing defaults
-require'nvim-lightbulb'.update_lightbulb {
+require'nvim-lightbulb'.setup {
     -- LSP client names to ignore
     -- Example: {"sumneko_lua", "null-ls"}
     ignore = {},
@@ -87,6 +90,19 @@ require'nvim-lightbulb'.update_lightbulb {
         text_unavailable = ""
     }
 }
+```
+##### Per-call configuration
+
+You can overwrite the defaults by passing options to the `update_lightbulb` function.
+
+VimScript:
+```vim
+autocmd CursorHold,CursorHoldI * lua require'nvim-lightbulb'.update_lightbulb({ ignore = {"null-ls"} })
+```
+
+Lua:
+```lua
+vim.cmd [[autocmd CursorHold,CursorHoldI * lua require'nvim-lightbulb'.update_lightbulb({ ignore = {"null-ls"} })]]
 ```
 
 ##### Modify the [lightbulb sign](https://neovim.io/doc/user/sign.html#:sign-define):

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,0 +1,41 @@
+local config = {}
+
+local default_opts = {
+	sign = {
+		enabled = true,
+		priority = 10,
+	},
+	float = {
+		enabled = false,
+		text = "💡",
+		win_opts = {},
+	},
+	virtual_text = {
+		enabled = false,
+		text = "💡",
+		hl_mode = "replace",
+	},
+	status_text = {
+		enabled = false,
+		text = "💡",
+		text_unavailable = "",
+	},
+	ignore = {},
+}
+
+--- Build a configuration based on the `default_opts` and accept overwrites
+--- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, ignore
+--- @return table
+config.build = function(opts)
+	opts = opts or {}
+	return vim.tbl_deep_extend("force", default_opts, opts)
+end
+
+--- Set default configuration
+--- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, ignore
+config.set_defaults = function(opts)
+	local new_opts = config.build(opts)
+	default_opts = new_opts
+end
+
+return config

--- a/lua/nvim-lightbulb.lua
+++ b/lua/nvim-lightbulb.lua
@@ -192,28 +192,7 @@ end
 
 M.update_lightbulb = function(config)
     config = config or {}
-    local opts = {
-        sign = {
-            enabled = true,
-            priority = 10,
-        },
-        float = {
-            enabled = false,
-            text = "💡",
-            win_opts = {},
-        },
-        virtual_text = {
-            enabled = false,
-            text = "💡",
-            hl_mode = "replace"
-        },
-        status_text = {
-            enabled = false,
-            text = "💡",
-            text_unavailable = ""
-        },
-        ignore = {},
-    }
+    local opts = require("config").build(config)
 
     -- Key: client.name
     -- Value: true if ignore
@@ -271,6 +250,13 @@ M.update_lightbulb = function(config)
     vim.lsp.buf_request_all(
         0, 'textDocument/codeAction', params, handler_factory(opts, params.range.start.line, bufnr)
     )
+end
+
+--- Setup function that configures the defaults.
+--- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, ignore
+M.setup = function(opts)
+  opts = opts or {}
+  require("config").set_defaults(opts)
 end
 
 return M


### PR DESCRIPTION
This PR attempts to fix #2 by adding a setup function, the same pattern as other plugins are using, like [telescope](https://github.com/nvim-telescope/telescope.nvim#telescope-setup-structure), [octo.nvim](https://github.com/nvim-telescope/telescope.nvim#telescope-setup-structure), among others.

I couldn't find a better example for "Per-call" configuration in the README file, so I'll be happy to update it if you have a better use case!

I was wondering also if adding a sample snippet on how to configure it with packer or other plugin managers will be useful, i.e:

```lua
use {
  "kosayoda/nvim-lightbulb",
  config = function()
    require'nvim-lightbulb'.setup({
      ignore = {"null-ls"},
    })

    vim.cmd [[autocmd CursorHold,CursorHoldI * lua require'nvim-lightbulb'.update_lightbulb()]]
  end,
}
```

Thank you!