### PR TITLE
fix lightbulb do not show when sometimes lsp client index not started…

### DIFF
--- a/lua/nvim-lightbulb/init.lua
+++ b/lua/nvim-lightbulb/init.lua
@@ -205,14 +205,16 @@ M.update_lightbulb = function(config)
 
     -- Check for code action capability
     local code_action_cap_found = false
-    for _, client in ipairs(vim.lsp.buf_get_clients()) do
-        if client.supports_method("textDocument/codeAction") then
-            -- If it is ignored, add the id to the ignore table for the handler
-            if ignored_clients[client.name] then
-              opts.ignore[client.id] = true
-            else
-              -- Otherwise we have found a capable client
-              code_action_cap_found = true
+    for _, client in pairs(vim.lsp.buf_get_clients()) do
+        if client then
+            if client.supports_method("textDocument/codeAction") then
+                -- If it is ignored, add the id to the ignore table for the handler
+                if ignored_clients[client.name] then
+                  opts.ignore[client.id] = true
+                else
+                  -- Otherwise we have found a capable client
+                  code_action_cap_found = true
+                end
             end
         end
     end


### PR DESCRIPTION
Thanks! This plugin is very useful to me. But I do not know why sometimes the index of `buf lsp client` is not started with `1`. Thus, Lua's `ipairs` will not work. I think it is better to protect this in our code, or do you have any better ideas?

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/44762000/166093379-c677e131-ab5b-447f-93dc-3e83a7fcfdf3.png">

