### PR TITLE
Add automatic autocmd creation to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Lua:
 vim.cmd [[autocmd CursorHold,CursorHoldI * lua require'nvim-lightbulb'.update_lightbulb()]]
 ```
 
+It is also possible to let the plugin create this autocommand for you. This can be enabled using the `setup` function:
+
+```lua
+require('nvim-lightbulb).setup({autocmd = {enabled = true}})
+```
+
+For all options, see the Configuration section.
 
 ### Configuration
 
@@ -88,6 +95,13 @@ require'nvim-lightbulb'.setup {
         text = "💡",
         -- Text to provide when no actions are available
         text_unavailable = ""
+    }
+    autocmd = {
+        enabled = false,
+        -- see :help autocmd-pattern
+        pattern = {"*"},
+        -- see :help autocmd-events
+        events = {"CursorHold", "CursorHoldI"}
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ Call `require('nvim-lightbulb').update_lightbulb()` whenever you want to show a 
 
 VimScript:
 ```vim
-autocmd CursorHold,CursorHoldI * lua require'nvim-lightbulb'.update_lightbulb()
+autocmd CursorHold,CursorHoldI * lua require('nvim-lightbulb').update_lightbulb()
 ```
 
 Lua:
 ```lua
-vim.cmd [[autocmd CursorHold,CursorHoldI * lua require'nvim-lightbulb'.update_lightbulb()]]
+vim.cmd [[autocmd CursorHold,CursorHoldI * lua require('nvim-lightbulb').update_lightbulb()]]
 ```
 
 It is also possible to let the plugin create this autocommand for you. This can be enabled using the `setup` function:
 
 ```lua
-require('nvim-lightbulb).setup({autocmd = {enabled = true}})
+require('nvim-lightbulb').setup({autocmd = {enabled = true}})
 ```
 
 For all options, see the Configuration section.
@@ -53,7 +53,7 @@ Configuration can be passed to the setup function.
 
 ```lua
 -- Showing defaults
-require'nvim-lightbulb'.setup {
+require('nvim-lightbulb').setup({
     -- LSP client names to ignore
     -- Example: {"sumneko_lua", "null-ls"}
     ignore = {},
@@ -103,8 +103,9 @@ require'nvim-lightbulb'.setup {
         -- see :help autocmd-events
         events = {"CursorHold", "CursorHoldI"}
     }
-}
+})
 ```
+
 ##### Per-call configuration
 
 You can overwrite the defaults by passing options to the `update_lightbulb` function.
@@ -155,5 +156,5 @@ vim.api.nvim_command('highlight LightBulbVirtualText ctermfg= ctermbg= guifg= gu
 ##### Status-line text usage
 
 With the status_text option enabled you can access the current lightbulb state
-through the lua function `require'nvim-lightbulb'.get_status_text()`. This
+through the lua function `require('nvim-lightbulb').get_status_text()`. This
 allows easy integration with multiple different status line plugins.

--- a/lua/nvim-lightbulb/config.lua
+++ b/lua/nvim-lightbulb/config.lua
@@ -32,13 +32,23 @@ local default_opts = {
 --- @param events table: Same as events key in opts param of vim.api.nvim_create_augroup
 --- @param pattern table: Same as pattern key in opts param of vim.api.nvim_create_augroup
 local _create_autocmd = function(events, pattern)
-	local id = vim.api.nvim_create_augroup("LightBulb", {})
-	vim.api.nvim_create_autocmd(events, {
-		pattern = pattern,
-		group = id,
-		desc = "lua require('nvim-lightbulb').update_lightbulb()",
-		callback = require("nvim-lightbulb").update_lightbulb
-	})
+	-- can be deleted when wished to drop support for versions below 0.7
+	if not vim.fn.has("nvim-0.7") then
+		vim.cmd(string.format([[
+			augroup LightBulb
+				autocmd!
+				autocmd %s %s lua require('nvim-lightbulb').update_lightbulb()
+			augroup end
+		]], table.concat(events, ","), table.concat(pattern, ",")))
+	else
+		local id = vim.api.nvim_create_augroup("LightBulb", {})
+		vim.api.nvim_create_autocmd(events, {
+			pattern = pattern,
+			group = id,
+			desc = "lua require('nvim-lightbulb').update_lightbulb()",
+			callback = require("nvim-lightbulb").update_lightbulb
+		})
+	end
 end
 
 --- Build a configuration based on the `default_opts` and accept overwrites

--- a/lua/nvim-lightbulb/config.lua
+++ b/lua/nvim-lightbulb/config.lua
@@ -1,73 +1,73 @@
 local config = {}
 
 local default_opts = {
-	sign = {
-		enabled = true,
-		priority = 10,
-	},
-	float = {
-		enabled = false,
-		text = "💡",
-		win_opts = {},
-	},
-	virtual_text = {
-		enabled = false,
-		text = "💡",
-		hl_mode = "replace",
-	},
-	status_text = {
-		enabled = false,
-		text = "💡",
-		text_unavailable = "",
-	},
-	autocmd = {
-		enabled = false,
-		events = {"CursorHold", "CursorHoldI"},
-		pattern = {"*"},
-	},
-	ignore = {},
+  sign = {
+    enabled = true,
+    priority = 10,
+  },
+  float = {
+    enabled = false,
+    text = "💡",
+    win_opts = {},
+  },
+  virtual_text = {
+    enabled = false,
+    text = "💡",
+    hl_mode = "replace",
+  },
+  status_text = {
+    enabled = false,
+    text = "💡",
+    text_unavailable = "",
+  },
+  autocmd = {
+    enabled = false,
+    events = { "CursorHold", "CursorHoldI" },
+    pattern = { "*" },
+  },
+  ignore = {},
 }
 
 --- Create augroup and autocmd that calls update_lightbulb
 --- @param events table: Same as events key in opts param of vim.api.nvim_create_augroup
 --- @param pattern table: Same as pattern key in opts param of vim.api.nvim_create_augroup
 local _create_autocmd = function(events, pattern)
-	-- can be deleted when wished to drop support for versions below 0.7
-	if vim.fn.has("nvim-0.7") == 1 then
-		local id = vim.api.nvim_create_augroup("LightBulb", {})
-		vim.api.nvim_create_autocmd(events, {
-			pattern = pattern,
-			group = id,
-			desc = "lua require('nvim-lightbulb').update_lightbulb()",
-			callback = require("nvim-lightbulb").update_lightbulb
-		})
-	else
-		vim.cmd(string.format([[
-			augroup LightBulb
-				autocmd!
-				autocmd %s %s lua require('nvim-lightbulb').update_lightbulb()
-			augroup end
-		]], table.concat(events, ","), table.concat(pattern, ",")))
-	end
+  -- can be deleted when wished to drop support for versions below 0.7
+  if vim.fn.has("nvim-0.7") == 1 then
+    local id = vim.api.nvim_create_augroup("LightBulb", {})
+    vim.api.nvim_create_autocmd(events, {
+      pattern = pattern,
+      group = id,
+      desc = "lua require('nvim-lightbulb').update_lightbulb()",
+      callback = require("nvim-lightbulb").update_lightbulb
+    })
+  else
+    vim.cmd(string.format([[
+      augroup LightBulb
+              autocmd!
+              autocmd %s %s lua require('nvim-lightbulb').update_lightbulb()
+      augroup end
+    ]] , table.concat(events, ","), table.concat(pattern, ",")))
+  end
 end
 
 --- Build a configuration based on the `default_opts` and accept overwrites
 --- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, autocmd, ignore
 --- @return table
 config.build = function(opts)
-	opts = opts or {}
-	return vim.tbl_deep_extend("force", default_opts, opts)
+  opts = opts or {}
+  return vim.tbl_deep_extend("force", default_opts, opts)
 end
 
 --- Set default configuration
 --- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, autocmd, ignore
 config.set_defaults = function(opts)
-	local new_opts = config.build(opts)
-	default_opts = new_opts
+  local new_opts = config.build(opts)
+  default_opts = new_opts
 
-	if default_opts.autocmd.enabled then
-		_create_autocmd(default_opts.autocmd.events, default_opts.autocmd.pattern)
-	end
+  if default_opts.autocmd.enabled then
+    _create_autocmd(default_opts.autocmd.events, default_opts.autocmd.pattern)
+  end
 end
 
 return config

--- a/lua/nvim-lightbulb/config.lua
+++ b/lua/nvim-lightbulb/config.lua
@@ -20,11 +20,29 @@ local default_opts = {
 		text = "💡",
 		text_unavailable = "",
 	},
+	autocmd = {
+		enabled = false,
+		events = {"CursorHold", "CursorHoldI"},
+		pattern = {"*"},
+	},
 	ignore = {},
 }
 
+--- Create augroup and autocmd that calls update_lightbulb
+--- @param events table: Same as events key in opts param of vim.api.nvim_create_augroup
+--- @param pattern table: Same as pattern key in opts param of vim.api.nvim_create_augroup
+local _create_autocmd = function(events, pattern)
+	local id = vim.api.nvim_create_augroup("LightBulb", {})
+	vim.api.nvim_create_autocmd(events, {
+		pattern = pattern,
+		group = id,
+		desc = "lua require('nvim-lightbulb').update_lightbulb()",
+		callback = require("nvim-lightbulb").update_lightbulb
+	})
+end
+
 --- Build a configuration based on the `default_opts` and accept overwrites
---- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, ignore
+--- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, autocmd, ignore
 --- @return table
 config.build = function(opts)
 	opts = opts or {}
@@ -32,10 +50,14 @@ config.build = function(opts)
 end
 
 --- Set default configuration
---- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, ignore
+--- @param opts table: Partial or full configuration opts. Keys: sign, float, virtual_text, status_text, autocmd, ignore
 config.set_defaults = function(opts)
 	local new_opts = config.build(opts)
 	default_opts = new_opts
+
+	if default_opts.autocmd.enabled then
+		_create_autocmd(default_opts.autocmd.events, default_opts.autocmd.pattern)
+	end
 end
 
 return config

--- a/lua/nvim-lightbulb/config.lua
+++ b/lua/nvim-lightbulb/config.lua
@@ -33,14 +33,7 @@ local default_opts = {
 --- @param pattern table: Same as pattern key in opts param of vim.api.nvim_create_augroup
 local _create_autocmd = function(events, pattern)
 	-- can be deleted when wished to drop support for versions below 0.7
-	if not vim.fn.has("nvim-0.7") then
-		vim.cmd(string.format([[
-			augroup LightBulb
-				autocmd!
-				autocmd %s %s lua require('nvim-lightbulb').update_lightbulb()
-			augroup end
-		]], table.concat(events, ","), table.concat(pattern, ",")))
-	else
+	if vim.fn.has("nvim-0.7") == 1 then
 		local id = vim.api.nvim_create_augroup("LightBulb", {})
 		vim.api.nvim_create_autocmd(events, {
 			pattern = pattern,
@@ -48,6 +41,13 @@ local _create_autocmd = function(events, pattern)
 			desc = "lua require('nvim-lightbulb').update_lightbulb()",
 			callback = require("nvim-lightbulb").update_lightbulb
 		})
+	else
+		vim.cmd(string.format([[
+			augroup LightBulb
+				autocmd!
+				autocmd %s %s lua require('nvim-lightbulb').update_lightbulb()
+			augroup end
+		]], table.concat(events, ","), table.concat(pattern, ",")))
 	end
 end
 

--- a/lua/nvim-lightbulb/init.lua
+++ b/lua/nvim-lightbulb/init.lua
@@ -10,7 +10,7 @@ local LIGHTBULB_VIRTUAL_TEXT_NS = vim.api.nvim_create_namespace("nvim-lightbulb"
 
 -- Set default sign
 if vim.tbl_isempty(vim.fn.sign_getdefined(SIGN_NAME)) then
-    vim.fn.sign_define(SIGN_NAME, { text = "💡", texthl = "LspDiagnosticsDefaultInformation" })
+  vim.fn.sign_define(SIGN_NAME, { text = "💡", texthl = "LspDiagnosticsDefaultInformation" })
 end
 
 --- Update lightbulb float.
@@ -20,30 +20,30 @@ end
 ---
 --- @private
 local function _update_float(opts, bufnr)
-    bufnr = bufnr or vim.api.nvim_get_current_buf()
-    -- prevent `open_floating_preview` close the previous floating window
-    vim.api.nvim_buf_set_var(bufnr, "lsp_floating_preview", nil)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  -- prevent `open_floating_preview` close the previous floating window
+  vim.api.nvim_buf_set_var(bufnr, "lsp_floating_preview", nil)
 
-    -- check if another lightbulb floating window already exists for this buffer
-    -- and close it if needed
-    local existing_float = vim.F.npcall(vim.api.nvim_buf_get_var, bufnr, "lightbulb_floating_window")
-    if existing_float and vim.api.nvim_win_is_valid(existing_float) then
-      vim.api.nvim_win_close(existing_float, true)
-    end
+  -- check if another lightbulb floating window already exists for this buffer
+  -- and close it if needed
+  local existing_float = vim.F.npcall(vim.api.nvim_buf_get_var, bufnr, "lightbulb_floating_window")
+  if existing_float and vim.api.nvim_win_is_valid(existing_float) then
+    vim.api.nvim_win_close(existing_float, true)
+  end
 
-    local _, win = lsp_util.open_floating_preview({ opts.text }, "plaintext", opts.win_opts)
-    vim.api.nvim_win_set_option(win, "winhl", "Normal:" .. LIGHTBULB_FLOAT_HL)
+  local _, win = lsp_util.open_floating_preview({ opts.text }, "plaintext", opts.win_opts)
+  vim.api.nvim_win_set_option(win, "winhl", "Normal:" .. LIGHTBULB_FLOAT_HL)
 
-    -- Manually anchor float because `open_floating_preview` doesn't support that option
-    if opts.win_opts["anchor"] ~= nil then
-        vim.api.nvim_win_set_config(win, { anchor = opts.win_opts.anchor })
-    end
+  -- Manually anchor float because `open_floating_preview` doesn't support that option
+  if opts.win_opts["anchor"] ~= nil then
+    vim.api.nvim_win_set_config(win, { anchor = opts.win_opts.anchor })
+  end
 
-    if opts.win_opts["winblend"] ~= nil then
-        vim.api.nvim_win_set_option(win, "winblend", opts.win_opts.winblend)
-    end
+  if opts.win_opts["winblend"] ~= nil then
+    vim.api.nvim_win_set_option(win, "winblend", opts.win_opts.winblend)
+  end
 
-    vim.api.nvim_buf_set_var(bufnr, "lightbulb_floating_window", win)
+  vim.api.nvim_buf_set_var(bufnr, "lightbulb_floating_window", win)
 end
 
 --- Update sign position from `old_line` to `new_line`.
@@ -58,26 +58,26 @@ end
 ---
 --- @private
 local function _update_sign(priority, old_line, new_line, bufnr)
-    bufnr = bufnr or "%"
+  bufnr = bufnr or "%"
 
-    if old_line then
-        vim.fn.sign_unplace(
-            SIGN_GROUP, { id = old_line, buffer = bufnr }
-        )
+  if old_line then
+    vim.fn.sign_unplace(
+      SIGN_GROUP, { id = old_line, buffer = bufnr }
+    )
 
-        -- Update current lightbulb line
-        vim.b.lightbulb_line = nil
-    end
+    -- Update current lightbulb line
+    vim.b.lightbulb_line = nil
+  end
 
-    -- Avoid redrawing lightbulb if code action line did not change
-    if new_line and (vim.b.lightbulb_line ~= new_line) then
-        vim.fn.sign_place(
-            new_line, SIGN_GROUP, SIGN_NAME, bufnr,
-            { lnum = new_line, priority = priority }
-        )
-        -- Update current lightbulb line
-        vim.b.lightbulb_line = new_line
-    end
+  -- Avoid redrawing lightbulb if code action line did not change
+  if new_line and (vim.b.lightbulb_line ~= new_line) then
+    vim.fn.sign_place(
+      new_line, SIGN_GROUP, SIGN_NAME, bufnr,
+      { lnum = new_line, priority = priority }
+    )
+    -- Update current lightbulb line
+    vim.b.lightbulb_line = new_line
+  end
 end
 
 --- Update lightbulb virtual text.
@@ -88,14 +88,14 @@ end
 ---
 --- @private
 local function _update_virtual_text(opts, line, bufnr)
-    bufnr = bufnr or vim.api.nvim_get_current_buf()
-    vim.api.nvim_buf_clear_namespace(bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, 0, -1)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_clear_namespace(bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, 0, -1)
 
-    if line then
-        vim.api.nvim_buf_set_extmark(
-            bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, line, -1, { virt_text = {{ opts.text, LIGHTBULB_VIRTUAL_TEXT_HL }}, hl_mode = opts.hl_mode }
-        )
-    end
+  if line then
+    vim.api.nvim_buf_set_extmark(
+      bufnr, LIGHTBULB_VIRTUAL_TEXT_NS, line, -1, { virt_text = { { opts.text, LIGHTBULB_VIRTUAL_TEXT_HL } }, hl_mode = opts.hl_mode }
+    )
+  end
 end
 
 --- Update lightbulb status text
@@ -104,10 +104,9 @@ end
 --- @param bufnr number|nil Buffer handle
 ---
 local function _update_status_text(text, bufnr)
-    bufnr = bufnr or vim.api.nvim_get_current_buf()
-    vim.api.nvim_buf_set_var(bufnr, 'current_lightbulb_status_text', text)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_set_var(bufnr, 'current_lightbulb_status_text', text)
 end
-
 
 --- Patch for breaking neovim master update to LSP handlers
 --- See: https://github.com/neovim/neovim/issues/14090#issuecomment-913198455
@@ -136,122 +135,122 @@ end
 --- @param bufnr number|nil Buffer handle
 --- @private
 local function handler_factory(opts, line, bufnr)
-    --- Handler for textDocument/codeAction.
-    ---
-    --- See lsp-handler for more information.
-    ---
-    --- @private
-    local function code_action_handler(responses)
-        -- Check for available code actions from all LSP server responses
-        local has_actions = false
-        for client_id, resp in pairs(responses) do
-            if resp.result and not opts.ignore[client_id] and not vim.tbl_isempty(resp.result) then
-                has_actions = true
-                break
-            end
-        end
-
-        -- No available code actions
-        if not has_actions then
-            if opts.sign.enabled then
-                _update_sign(opts.sign.priority, vim.b.lightbulb_line, nil, bufnr)
-            end
-            if opts.virtual_text.enabled then
-                _update_virtual_text(opts.virtual_text, nil, bufnr)
-            end
-            if opts.status_text.enabled then
-                _update_status_text(opts.status_text.text_unavailable, bufnr)
-            end
-        else
-            if opts.sign.enabled then
-                _update_sign(opts.sign.priority, vim.b.lightbulb_line, line + 1, bufnr)
-            end
-
-            if opts.float.enabled then
-                _update_float(opts.float, bufnr)
-            end
-
-            if opts.virtual_text.enabled then
-                _update_virtual_text(opts.virtual_text, line, bufnr)
-            end
-
-            if opts.status_text.enabled then
-                _update_status_text(opts.status_text.text, bufnr)
-            end
-        end
-
-    end
-
-    return mk_handler(code_action_handler)
-end
-
-M.get_status_text = function(bufnr)
-    bufnr = bufnr or vim.api.nvim_get_current_buf()
-    return vim.F.npcall(vim.api.nvim_buf_get_var, bufnr, "current_lightbulb_status_text") or ""
-end
-
-M.update_lightbulb = function(config)
-    config = config or {}
-    local opts = require("nvim-lightbulb.config").build(config)
-
-    -- Key: client.name
-    -- Value: true if ignore
-    local ignored_clients = {}
-    if config.ignore then
-      for _, client in ipairs(config.ignore) do
-        ignored_clients[client] = true
+  --- Handler for textDocument/codeAction.
+  ---
+  --- See lsp-handler for more information.
+  ---
+  --- @private
+  local function code_action_handler(responses)
+    -- Check for available code actions from all LSP server responses
+    local has_actions = false
+    for client_id, resp in pairs(responses) do
+      if resp.result and not opts.ignore[client_id] and not vim.tbl_isempty(resp.result) then
+        has_actions = true
+        break
       end
     end
 
-    -- Check for code action capability
-    local code_action_cap_found = false
-    for _, client in pairs(vim.lsp.buf_get_clients()) do
-        if client then
-            if client.supports_method("textDocument/codeAction") then
-                -- If it is ignored, add the id to the ignore table for the handler
-                if ignored_clients[client.name] then
-                  opts.ignore[client.id] = true
-                else
-                  -- Otherwise we have found a capable client
-                  code_action_cap_found = true
-                end
-            end
+    -- No available code actions
+    if not has_actions then
+      if opts.sign.enabled then
+        _update_sign(opts.sign.priority, vim.b.lightbulb_line, nil, bufnr)
+      end
+      if opts.virtual_text.enabled then
+        _update_virtual_text(opts.virtual_text, nil, bufnr)
+      end
+      if opts.status_text.enabled then
+        _update_status_text(opts.status_text.text_unavailable, bufnr)
+      end
+    else
+      if opts.sign.enabled then
+        _update_sign(opts.sign.priority, vim.b.lightbulb_line, line + 1, bufnr)
+      end
+
+      if opts.float.enabled then
+        _update_float(opts.float, bufnr)
+      end
+
+      if opts.virtual_text.enabled then
+        _update_virtual_text(opts.virtual_text, line, bufnr)
+      end
+
+      if opts.status_text.enabled then
+        _update_status_text(opts.status_text.text, bufnr)
+      end
+    end
+
+  end
+
+  return mk_handler(code_action_handler)
+end
+
+M.get_status_text = function(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  return vim.F.npcall(vim.api.nvim_buf_get_var, bufnr, "current_lightbulb_status_text") or ""
+end
+
+M.update_lightbulb = function(config)
+  config = config or {}
+  local opts = require("nvim-lightbulb.config").build(config)
+
+  -- Key: client.name
+  -- Value: true if ignore
+  local ignored_clients = {}
+  if config.ignore then
+    for _, client in ipairs(config.ignore) do
+      ignored_clients[client] = true
+    end
+  end
+
+  -- Check for code action capability
+  local code_action_cap_found = false
+  for _, client in pairs(vim.lsp.buf_get_clients()) do
+    if client then
+      if client.supports_method("textDocument/codeAction") then
+        -- If it is ignored, add the id to the ignore table for the handler
+        if ignored_clients[client.name] then
+          opts.ignore[client.id] = true
+        else
+          -- Otherwise we have found a capable client
+          code_action_cap_found = true
         end
+      end
     end
-    if not code_action_cap_found then
-        return
-    end
+  end
+  if not code_action_cap_found then
+    return
+  end
 
-    -- Backwards compatibility
-    opts.sign.priority = config.sign_priority or opts.sign.priority
+  -- Backwards compatibility
+  opts.sign.priority = config.sign_priority or opts.sign.priority
 
-    -- Sign configuration
-    for k, v in pairs(config.sign or {}) do
-        opts.sign[k] = v
-    end
+  -- Sign configuration
+  for k, v in pairs(config.sign or {}) do
+    opts.sign[k] = v
+  end
 
-    -- Float configuration
-    for k, v in pairs(config.float or {}) do
-        opts.float[k] = v
-    end
+  -- Float configuration
+  for k, v in pairs(config.float or {}) do
+    opts.float[k] = v
+  end
 
-    -- Virtual text configuration
-    for k, v in pairs(config.virtual_text or {}) do
-        opts.virtual_text[k] = v
-    end
+  -- Virtual text configuration
+  for k, v in pairs(config.virtual_text or {}) do
+    opts.virtual_text[k] = v
+  end
 
-    -- Status text configuration
-    for k, v in pairs(config.status_text or {}) do
-        opts.status_text[k] = v
-    end
+  -- Status text configuration
+  for k, v in pairs(config.status_text or {}) do
+    opts.status_text[k] = v
+  end
 
-    local context = { diagnostics = vim.lsp.diagnostic.get_line_diagnostics() }
-    local params = lsp_util.make_range_params()
-    params.context = context
-    local bufnr = vim.api.nvim_get_current_buf()
-    vim.lsp.buf_request_all(
-        0, 'textDocument/codeAction', params, handler_factory(opts, params.range.start.line, bufnr)
-    )
+  local context = { diagnostics = vim.lsp.diagnostic.get_line_diagnostics() }
+  local params = lsp_util.make_range_params()
+  params.context = context
+  local bufnr = vim.api.nvim_get_current_buf()
+  vim.lsp.buf_request_all(
+    0, 'textDocument/codeAction', params, handler_factory(opts, params.range.start.line, bufnr)
+  )
 end
 
 --- Setup function that configures the defaults.


### PR DESCRIPTION
This PR adds the default configuration for the autocmd config, a function that creates the augroup "LightBulb" and adds an autocmd to this group. This function is called in `config.setup` if `default_config.autocmd.enabled` is set to true.

I chose to use the keyword `pattern` instead of `patterns` to make it the same as the nvim API for autocmds.

Closes #32.