### PR TITLE
Fix #39

### DIFF
--- a/lua/nvim-lightbulb/init.lua
+++ b/lua/nvim-lightbulb/init.lua
@@ -144,7 +144,7 @@ local function handler_factory(opts, line, bufnr)
     -- Check for available code actions from all LSP server responses
     local has_actions = false
     for client_id, resp in pairs(responses) do
-      if resp.result and not opts.ignore[client_id] and not vim.tbl_isempty(resp.result) then
+      if resp.result and not opts.ignore_id[client_id] and not vim.tbl_isempty(resp.result) then
         has_actions = true
         break
       end
@@ -192,6 +192,7 @@ end
 M.update_lightbulb = function(config)
   config = config or {}
   local opts = require("nvim-lightbulb.config").build(config)
+  opts.ignore_id = {}
 
   -- Key: client.name
   -- Value: true if ignore
@@ -209,7 +210,7 @@ M.update_lightbulb = function(config)
       if client.supports_method("textDocument/codeAction") then
         -- If it is ignored, add the id to the ignore table for the handler
         if ignored_clients[client.name] then
-          opts.ignore[client.id] = true
+          opts.ignore_id[client.id] = true
         else
           -- Otherwise we have found a capable client
           code_action_cap_found = true

--- a/lua/nvim-lightbulb/init.lua
+++ b/lua/nvim-lightbulb/init.lua
@@ -197,8 +197,8 @@ M.update_lightbulb = function(config)
   -- Key: client.name
   -- Value: true if ignore
   local ignored_clients = {}
-  if config.ignore then
-    for _, client in ipairs(config.ignore) do
+  if opts.ignore then
+    for _, client in ipairs(opts.ignore) do
       ignored_clients[client] = true
     end
   end
@@ -223,25 +223,25 @@ M.update_lightbulb = function(config)
   end
 
   -- Backwards compatibility
-  opts.sign.priority = config.sign_priority or opts.sign.priority
+  opts.sign.priority = opts.sign_priority or opts.sign.priority
 
   -- Sign configuration
-  for k, v in pairs(config.sign or {}) do
+  for k, v in pairs(opts.sign or {}) do
     opts.sign[k] = v
   end
 
   -- Float configuration
-  for k, v in pairs(config.float or {}) do
+  for k, v in pairs(opts.float or {}) do
     opts.float[k] = v
   end
 
   -- Virtual text configuration
-  for k, v in pairs(config.virtual_text or {}) do
+  for k, v in pairs(opts.virtual_text or {}) do
     opts.virtual_text[k] = v
   end
 
   -- Status text configuration
-  for k, v in pairs(config.status_text or {}) do
+  for k, v in pairs(opts.status_text or {}) do
     opts.status_text[k] = v
   end
 


### PR DESCRIPTION
This PR contains 2 commits and should fix #39.

The first commit adds an `ignore_id` option to `opts` in `update_lightbulb`. That is because if we just set `opts.ignore[client.id] = true` in [init.lua:201](https://github.com/kosayoda/nvim-lightbulb/blob/master/lua/nvim-lightbulb/init.lua#L201), the ignore table will be messed up.

For example, if we have two client `clangd` which have the id 1, and `null-ls`, which have the id 2. Then set ignore to `{"null-ls"}`, after [init.lua:201](https://github.com/kosayoda/nvim-lightbulb/blob/master/lua/nvim-lightbulb/init.lua#L201), the `ignore` will be `{"null-ls", true}`.
So when code comes to [init.lua:147](https://github.com/kosayoda/nvim-lightbulb/blob/master/lua/nvim-lightbulb/init.lua#L147), for `clangd` that has id 1, the `not opts.ignore[client_id]` will also be `false` because `not "null-ls" = false`. So storing the client id in a standalone field will prevent the table to be messed up. 

The second commit change `config` usage into `opts` because `config` will not respect the default options that are set by `setup` but `opts` will.

I'm not very familiar with the code of the repo so if I break anything, feel free the change it.