### PR TITLE
Fix module name with underline instead of hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or, change the look of
 
 or, get a configured message
 
-6. as **status text**, retrievable with `require("nvim_lightbulb").get_status_text()`
+6. as **status text**, retrievable with `require("nvim-lightbulb").get_status_text()`
 
 ## Prerequisites
 
@@ -65,7 +65,7 @@ Plug 'kosayoda/nvim-lightbulb'
 Place this in your neovim configuration.
 
 ```lua
-require("nvim_lightbulb").setup({
+require("nvim-lightbulb").setup({
   autocmd = { enabled = true }
 })
 ```

--- a/doc/nvim-lightbulb.txt
+++ b/doc/nvim-lightbulb.txt
@@ -6,7 +6,7 @@
 
 Place this in your neovim configuration.
 >
-  require("nvim_lightbulb").setup({
+  require("nvim-lightbulb").setup({
     autocmd = { enabled = true }
   })
 

--- a/lua/nvim-lightbulb/init.lua
+++ b/lua/nvim-lightbulb/init.lua
@@ -5,7 +5,7 @@
 ---
 --- Place this in your neovim configuration.
 --- >
----   require("nvim_lightbulb").setup({
+---   require("nvim-lightbulb").setup({
 ---     autocmd = { enabled = true }
 ---   })
 ---


### PR DESCRIPTION
Apparently the module name is with hyphen and not underline, like we see in the readme and other places. I tried to install this plugin to try it out and `require('nvim_lightbulb')` does not work 😅