### PR TITLE
feat!: allow ignoring a list of code actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ local default_config = {
         -- Filetypes to ignore.
         -- Example: {"neo-tree", "lua"}
         ft = {},
-        -- Ignore code actions without a `kind` like refactor.rewrite, quickfix.
-        actions_without_kind = false,
+        -- Actions to ignore. To ignore code actions without a `kind` like refactor.rewrite, add "" to the table.
+        -- Example: {"source.fixAll", ""}
+        actions = {},
     },
 }
 ```

--- a/doc/nvim-lightbulb.txt
+++ b/doc/nvim-lightbulb.txt
@@ -212,8 +212,9 @@ Default values:
       -- Filetypes to ignore.
       -- Example: {"neo-tree", "lua"}
       ft = {},
-      -- Ignore code actions without a `kind` like refactor.rewrite, quickfix.
-      actions_without_kind = false,
+      -- Actions to ignore. To ignore code actions without a `kind` like refactor.rewrite, add "" to the table.
+      -- Example: {"source.fixAll", ""}
+      actions = {},
     },
   }
 

--- a/lua/nvim-lightbulb/config.lua
+++ b/lua/nvim-lightbulb/config.lua
@@ -129,8 +129,9 @@ local default_config = {
     -- Filetypes to ignore.
     -- Example: {"neo-tree", "lua"}
     ft = {},
-    -- Ignore code actions without a `kind` like refactor.rewrite, quickfix.
-    actions_without_kind = false,
+    -- Actions to ignore. To ignore code actions without a `kind` like refactor.rewrite, add "" to the table.
+    -- Example: {"source.fixAll", ""}
+    actions = {},
   },
 }
 
@@ -201,7 +202,7 @@ M.build = function(config, is_setup)
     ["autocmd.pattern"] = { config.autocmd.pattern, "table" },
     ["ignore.clients"] = { config.ignore.clients, "table" },
     ["ignore.ft"] = { config.ignore.ft, "table" },
-    ["ignore.actions_without_kind"] = { config.ignore.actions_without_kind, "boolean" },
+    ["ignore.actions"] = { config.ignore.actions, "table" },
   })
 
   return config

--- a/lua/nvim-lightbulb/init.lua
+++ b/lua/nvim-lightbulb/init.lua
@@ -159,13 +159,13 @@ local function handler_factory(opts, position, bufnr)
     local has_actions = false
     for client_id, resp in pairs(responses) do
       if resp.result and not opts.ignore_id[client_id] and not vim.tbl_isempty(resp.result) then
-        if not opts.ignore.actions_without_kind then
+        if vim.tbl_isempty(opts.ignore.actions) then
           has_actions = true
           break
         else
-          -- If we only want to get code actions with kind, we will have to check all results
+          -- Check if any of the results has a kind that's not ignored
           for _, r in pairs(resp.result) do
-            if r.kind and r.kind ~= "" then
+            if r.kind and not vim.tbl_contains(opts.ignore.actions, r.kind) then
               has_actions = true
             end
             break
@@ -407,9 +407,9 @@ NvimLightbulb.debug = function(config)
 
     for client_id, resp in pairs(responses) do
       if not opts.ignore_id[client_id] and resp.result and not vim.tbl_isempty(resp.result) then
-        if opts.ignore.actions_without_kind then
+        if not vim.tbl_isempty(opts.ignore.actions) then
           for _, r in pairs(resp.result) do
-            if r.kind and r.kind ~= "" then
+            if r.kind and not vim.tbl_contains(opts.ignore.actions, r.kind) then
               has_actions = true
               break
             end
@@ -427,11 +427,10 @@ NvimLightbulb.debug = function(config)
 
         local idx = 1
         for _, r in pairs(resp.result) do
-          local has_kind = r.kind and r.kind ~= ""
-          if not opts.ignore.actions_without_kind or has_kind then
+          if r.kind and not vim.tbl_contains(opts.ignore.actions, r.kind) then
             append(string.format("%d. %s", idx, r.title))
             idx = idx + 1
-            if has_kind then
+            if r.kind ~= "" then
               append(" " .. r.kind .. "\n", "Comment")
             else
               append(" (no kind)\n", "Comment")


### PR DESCRIPTION
Replaces ignore.actions_without_kind boolean with a table of ignored actions. To replicate actions_without_kind functionality add and empty string to the table.

Implements #51.