### PR TITLE
feat: allow changing the lightbulb icon if there are code lenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ local default_config = {
     -- See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind
     action_kinds = nil,
 
+    -- Enable code lens support.
+    -- If the current position has executable code lenses, the icon is changed from `text` to `lens_text`
+    -- for sign, virtual_text, float and status_text.
+    -- The code lens icon is configurable per handler.
+    code_lenses = false,
+
     -- Configuration for various handlers:
     -- 1. Sign column.
     sign = {
@@ -117,6 +123,7 @@ local default_config = {
         -- Text to show in the sign column.
         -- Must be between 1-2 characters.
         text = "💡",
+        lens_text = "🔎",
         -- Highlight group to highlight the sign column text.
         hl = "LightBulbSign",
     },
@@ -126,6 +133,7 @@ local default_config = {
         enabled = false,
         -- Text to show in the virt_text.
         text = "💡",
+        lens_text = "🔎",
         -- Position of virtual text given to |nvim_buf_set_extmark|.
         -- Can be a number representing a fixed column (see `virt_text_pos`).
         -- Can be a string representing a position (see `virt_text_win_col`).
@@ -142,6 +150,7 @@ local default_config = {
         enabled = false,
         -- Text to show in the floating window.
         text = "💡",
+        lens_text = "🔎",
         -- Highlight group to highlight the floating window.
         hl = "LightBulbFloatWin",
         -- Window options.
@@ -159,6 +168,7 @@ local default_config = {
         enabled = false,
         -- Text to set if a lightbulb is available.
         text = "💡",
+        lens_text = "🔎",
         -- Text to set if a lightbulb is unavailable.
         text_unavailable = "",
     },

--- a/doc/nvim-lightbulb.txt
+++ b/doc/nvim-lightbulb.txt
@@ -57,6 +57,9 @@ Usage~
 
 Display the lightbulb according to configuration.
 Any configuration provided overrides the defaults passed to |NvimLightbulb.setup|.
+|NvimLightbulb.config.code_lenses| enables checking if there are runnabled code 
+lenses under the cursor and potentially change the lightbulb icon using the
+|lens_text| handler configuration attribute.
 
 Parameters~
 {config} `(table|nil)` Partial or full configuration table. See |nvim-lightbulb-config|.
@@ -121,6 +124,12 @@ Default values:
     -- See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind
     action_kinds = nil,
 
+    -- Enable code lens support.
+    -- If the current position has executable code lenses, the icon is changed from `text` to `lens_text`
+    -- for sign, virtual_text, float and status_text.
+    -- The code lens icon is configurable per handler.
+    code_lenses = false,
+
     -- Configuration for various handlers:
     -- 1. Sign column.
     sign = {
@@ -128,6 +137,7 @@ Default values:
       -- Text to show in the sign column.
       -- Must be between 1-2 characters.
       text = "💡",
+      lens_text = "🔎",
       -- Highlight group to highlight the sign column text.
       hl = "LightBulbSign",
     },
@@ -137,6 +147,7 @@ Default values:
       enabled = false,
       -- Text to show in the virt_text.
       text = "💡",
+      lens_text = "🔎",
       -- Position of virtual text given to |nvim_buf_set_extmark|.
       -- Can be a number representing a fixed column (see `virt_text_pos`).
       -- Can be a string representing a position (see `virt_text_win_col`).
@@ -153,6 +164,7 @@ Default values:
       enabled = false,
       -- Text to show in the floating window.
       text = "💡",
+      lens_text = "🔎",
       -- Highlight group to highlight the floating window.
       hl = "LightBulbFloatWin",
       -- Window options.
@@ -170,6 +182,7 @@ Default values:
       enabled = false,
       -- Text to set if a lightbulb is available.
       text = "💡",
+      lens_text = "🔎",
       -- Text to set if a lightbulb is unavailable.
       text_unavailable = "",
     },

--- a/lua/nvim-lightbulb/config.lua
+++ b/lua/nvim-lightbulb/config.lua
@@ -38,6 +38,12 @@ local default_config = {
   -- See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind
   action_kinds = nil,
 
+  -- Enable code lens support.
+  -- If the current position has executable code lenses, the icon is changed from `text` to `lens_text`
+  -- for sign, virtual_text, float and status_text.
+  -- The code lens icon is configurable per handler.
+  code_lenses = false,
+
   -- Configuration for various handlers:
   -- 1. Sign column.
   sign = {
@@ -45,6 +51,7 @@ local default_config = {
     -- Text to show in the sign column.
     -- Must be between 1-2 characters.
     text = "💡",
+    lens_text = "🔎",
     -- Highlight group to highlight the sign column text.
     hl = "LightBulbSign",
   },
@@ -54,6 +61,7 @@ local default_config = {
     enabled = false,
     -- Text to show in the virt_text.
     text = "💡",
+    lens_text = "🔎",
     -- Position of virtual text given to |nvim_buf_set_extmark|.
     -- Can be a number representing a fixed column (see `virt_text_pos`).
     -- Can be a string representing a position (see `virt_text_win_col`).
@@ -70,6 +78,7 @@ local default_config = {
     enabled = false,
     -- Text to show in the floating window.
     text = "💡",
+    lens_text = "🔎",
     -- Highlight group to highlight the floating window.
     hl = "LightBulbFloatWin",
     -- Window options.
@@ -87,6 +96,7 @@ local default_config = {
     enabled = false,
     -- Text to set if a lightbulb is available.
     text = "💡",
+    lens_text = "🔎",
     -- Text to set if a lightbulb is unavailable.
     text_unavailable = "",
   },
@@ -165,6 +175,7 @@ M.build = function(config, is_setup)
     hide_in_unfocused_buffer = { config.hide_in_unfocused_buffer, "boolean" },
     link_highlights = { config.link_highlights, "boolean" },
     action_kinds = { config.action_kinds, "table", true },
+    code_lenses = { config.code_lenses, "boolean" },
     sign = { config.sign, "table" },
     virtual_text = { config.virtual_text, "table" },
     float = { config.float, "table" },


### PR DESCRIPTION
If `nvim-lightbulb` is configured with `code_lenses = true` and there are runnable code lenses under the cursor, the plugin can change the icon to a different one.

There are now 2 icons in most handlers, in the attribute `text` and `lens_text` and the latter is used in the conditions above.
