### PR TITLE
fix: avoid false positives due to gathering diagnostics from different buffer

### DIFF
--- a/lua/nvim-lightbulb/init.lua
+++ b/lua/nvim-lightbulb/init.lua
@@ -259,7 +259,7 @@ NvimLightbulb.update_lightbulb = function(config)
     pcall(vim.b[bufnr].lightbulb_lsp_cancel)
     vim.b[bufnr].lightbulb_lsp_cancel = nil
   end
-  local context = { diagnostics = vim.lsp.diagnostic.get_line_diagnostics() }
+  local context = { diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr) }
   context.only = opts.action_kinds
 
   local params = lsp_util.make_range_params()


### PR DESCRIPTION
As I was trying out this plugin, I noticed that code actions kept being shown on lines even when actions weren't available:
<img width="1691" alt="Screenshot 2024-09-16 at 11 50 39 PM" src="https://github.com/user-attachments/assets/eb226961-8f11-4406-b3d4-ff32f44dd454">

I dug into this and it seems like the reason is because `vim.lsp.diagnostic.get_line_diagnostics()` without any arguments seems to get diagnostics across the entire workspace:
<img width="1052" alt="Screenshot 2024-09-16 at 11 51 03 PM" src="https://github.com/user-attachments/assets/5bd234e6-f087-4cbc-b4c8-43d20c02982a">

I opened this PR as a fix to this by including just the bufnr in the call in case it was on purpose to try and include diagnostics not just on that line. By just adding the buffer it'll include diagnostics across the whole buffer. If we wanted to tighten this more we could add the line number as well but I wanted to open this up for discussion.