### PR TITLE
Fixed deprecation of vim.lsp.codelens.get

### DIFF
--- a/lua/nvim-lightbulb/init.lua
+++ b/lua/nvim-lightbulb/init.lua
@@ -65,7 +65,7 @@ local function is_code_lens(opts, position)
     return false
   end
   local codelens_actions = {}
-  for _, l in ipairs(vim.lsp.codelens.get(0)) do
+  for _, l in ipairs(vim.lsp.codelens.get({ bufnr = 0 })) do
     table.insert(codelens_actions, { start = l.range.start, finish = l.range["end"] })
   end
   for _, action in ipairs(codelens_actions) do


### PR DESCRIPTION
Directly passing the bufnr will be deprecated in 0.13: https://github.com/neovim/neovim/blob/596a7a32f392453bc406deb46ff9f650ce8fc4aa/runtime/lua/vim/lsp/codelens.lua#L348